### PR TITLE
feat: enhance health check endpoint with Soroban RPC integration

### DIFF
--- a/backend/src/health/health.controller.spec.ts
+++ b/backend/src/health/health.controller.spec.ts
@@ -1,0 +1,50 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { HealthController } from './health.controller';
+
+describe('HealthController', () => {
+  let controller: HealthController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [HealthController],
+      providers: [
+        {
+          provide: ConfigService,
+          useValue: {
+            get: (key: string) => {
+              if (key === 'SOROBAN_RPC_URL')
+                return 'https://soroban-testnet.stellar.org';
+              return undefined;
+            },
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<HealthController>(HealthController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  it('should return health status with expected shape', async () => {
+    const result = await controller.status();
+
+    expect(result).toHaveProperty('status');
+    expect(result).toHaveProperty('timestamp');
+    expect(result).toHaveProperty('version');
+    expect(result).toHaveProperty('uptime');
+    expect(result).toHaveProperty('services');
+    expect(result.services).toHaveProperty('soroban_rpc');
+    expect(result.services.soroban_rpc).toHaveProperty('ok');
+    expect(result.services.soroban_rpc).toHaveProperty('latency_ms');
+    expect(typeof result.services.soroban_rpc.latency_ms).toBe('number');
+  });
+
+  it('should return ok or degraded status', async () => {
+    const result = await controller.status();
+    expect(['ok', 'degraded']).toContain(result.status);
+  });
+});

--- a/backend/src/health/health.controller.ts
+++ b/backend/src/health/health.controller.ts
@@ -1,9 +1,73 @@
 import { Controller, Get } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Controller('health')
 export class HealthController {
+  private readonly rpcUrl: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.rpcUrl =
+      this.configService.get<string>('SOROBAN_RPC_URL') ||
+      'https://soroban-testnet.stellar.org';
+  }
+
   @Get()
-  status() {
-    return { status: 'ok', timestamp: new Date().toISOString() };
+  async status() {
+    const sorobanStatus = await this.checkSorobanRpc();
+
+    return {
+      status: sorobanStatus.ok ? 'ok' : 'degraded',
+      timestamp: new Date().toISOString(),
+      version: process.env.npm_package_version || '0.0.1',
+      uptime: process.uptime(),
+      services: {
+        soroban_rpc: sorobanStatus,
+      },
+    };
+  }
+
+  private async checkSorobanRpc(): Promise<{
+    ok: boolean;
+    latency_ms: number;
+    network?: string;
+    error?: string;
+  }> {
+    const start = Date.now();
+    try {
+      const response = await fetch(this.rpcUrl, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'getHealth',
+          params: [],
+        }),
+        signal: AbortSignal.timeout(5000),
+      });
+
+      const data = await response.json();
+      const latency = Date.now() - start;
+
+      if (data.result?.status === 'healthy') {
+        return {
+          ok: true,
+          latency_ms: latency,
+          network: this.rpcUrl.includes('testnet') ? 'testnet' : 'mainnet',
+        };
+      }
+
+      return {
+        ok: false,
+        latency_ms: latency,
+        error: `Unexpected RPC status: ${JSON.stringify(data.result)}`,
+      };
+    } catch (err) {
+      return {
+        ok: false,
+        latency_ms: Date.now() - start,
+        error: err instanceof Error ? err.message : 'RPC unreachable',
+      };
+    }
   }
 }

--- a/backend/src/health/health.module.ts
+++ b/backend/src/health/health.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { HealthController } from './health.controller';
 
 @Module({
+  imports: [ConfigModule],
   controllers: [HealthController],
 })
 export class HealthModule {}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -25,9 +25,20 @@ async function bootstrap() {
   const document = SwaggerModule.createDocument(app, configSwagger);
   SwaggerModule.setup('/api/docs', app, document);
 
+  app.enableShutdownHooks();
+
   const port = config.get('PORT') || 3000;
   await app.listen((port as number) || 3000);
 
   Logger.log(`Server started on http://localhost:${port}`);
+
+  const shutdown = async (signal: string) => {
+    Logger.log(`Received ${signal}, shutting down gracefully...`);
+    await app.close();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => shutdown('SIGTERM'));
+  process.on('SIGINT', () => shutdown('SIGINT'));
 }
 bootstrap();


### PR DESCRIPTION
Closes #13

## Summary
- Enhanced `/health` endpoint to ping Soroban RPC and report service status
- Returns JSON with `status` (ok/degraded), `timestamp`, `version`, `uptime`, and `services.soroban_rpc` (ok, latency_ms, network)
- Integrates with `ConfigService` for `SOROBAN_RPC_URL` (defaults to testnet)
- Added graceful shutdown on SIGTERM/SIGINT via `app.enableShutdownHooks()`
- Added unit tests for health controller

## Changes
- `backend/src/health/health.controller.ts` - Soroban RPC health check with timeout
- `backend/src/health/health.module.ts` - Import ConfigModule
- `backend/src/main.ts` - Graceful shutdown hooks
- `backend/src/health/health.controller.spec.ts` - Unit tests

/attempt 13